### PR TITLE
Set minimum-stability to dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,7 @@
         "psr-0": {
             "Behat\\Mink\\Driver": "src/"
         }
-    }
+    },
+
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Symfony/process 2.1 isn't stable yet, so allow dev releases.

Fixes #4
