### PR TITLE
Remove setValue() specific case for textarea

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -518,8 +518,7 @@ JS;
         $value = json_encode($value);
 
         $js = <<<JS
-var node = {$ref},
-
+var node = {$ref};
   var type = node.getAttribute('type');
   if (type == "checkbox") {
     {$value} ? browser.check(node) : browser.uncheck(node);
@@ -528,7 +527,6 @@ var node = {$ref},
   } else {
     browser.fill(node, {$value});
   }
-
 stream.end();
 JS;
         $this->server->evalJS($js);


### PR DESCRIPTION
setValue() method seems to eventually cause issues with javascript   (tested with angular-js)

In driver setValue() method process a different case when dealing  with textarea : it does not use the zombie.js method "fill".
According to Zombie API, fill deals with textarea too...so why deploy a different use cas for Textarea ?
