### PR TITLE
Added support for request headers

### DIFF
--- a/tests/Behat/Mink/Driver/ZombieDriverTest.php
+++ b/tests/Behat/Mink/Driver/ZombieDriverTest.php
@@ -54,11 +54,10 @@ class ZombieDriverTest extends JavascriptDriverTest
         $this->assertContains('foo bar', $session->getPage()->getText());
     }
 
-    /**
-     * @expectedException \Behat\Mink\Exception\UnsupportedDriverActionException
-     */
-    public function testNotAllowedHttpHeader()
+    public function testSetRequestHeader()
     {
         $this->getSession()->setRequestHeader('foo', 'bar');
+        $this->getSession()->visit($this->pathTo('/headers.php'));
+        $this->assertContains('[HTTP_FOO] => bar', $this->getSession()->getPage()->getText());
     }
 }


### PR DESCRIPTION
I added support for setting request headers.

I tested with zombie 1.4.1, installing 0.12.15 was getting very complicated (and I already spent like 2 hours just to have the tests working :/). I'll try to submit a PR to improve the documentation for running the tests.
