### PR TITLE
Bringing zombie back to life and making it compatible with 2.0.0 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - sudo sed -i -e "s,/var/www,$(pwd)/vendor/behat/mink/tests/Behat/Mink/Driver/web-fixtures,g" /etc/apache2/sites-available/default
   - sudo /etc/init.d/apache2 restart
 
-  - npm install zombie@0.12.15
+  - npm install zombie
 
   - export NODE_PATH="$(pwd)/node_modules"
   - export PATH="/usr/local/share/npm/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -11,30 +11,21 @@ You need a working installation of [NodeJS](http://nodejs.org/) and
 [zombie.js](http://zombie.labnotes.org) library through npm:
 
 ``` bash
-npm install -g zombie@0.12.15
+npm install -g zombie
 ```
 
-There are some compatibility issues with newer versions of zombie.js.
+There are some compatibility issues with older versions of zombie.js.
 Some are more or less PHP specific and kinda hard to resolve. If you
-want to be 100% on the safe side, please use __version 0.12.15 or
-lower__. 
-
-Versions > 0.12.15 and < 2.0.0 are almost compatible
-except for some edge cases.
-
-__Versions >= 2.0.0-alpha* (or above) are neither compatible nor
-supported at this
-point of time due to significant changes of the zombie.js API.__ As soon
-as version 2.0 is officially released, we will work on the driver's
-compatibility.
+want to be 100% on the safe side, please use __version 2.0.0-alpha1 or
+higher__.
 
 Use [Composer](http://getcomposer.org/) to install all required PHP dependencies:
 
 ``` json
 {
     "require": {
-        "behat/mink":               "1.4.*",
-        "behat/mink-zombie-driver": "1.0.*"
+        "behat/mink":               "~1.5",
+        "behat/mink-zombie-driver": "~1.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     "require": {
         "php":              ">=5.3.1",
-        "behat/mink":       "~1.5.0",
+        "behat/mink":       "~1.5.0@dev",
         "symfony/process":  "~2.1"
     },
 

--- a/tests/Behat/Mink/Driver/ZombieDriverTest.php
+++ b/tests/Behat/Mink/Driver/ZombieDriverTest.php
@@ -18,26 +18,45 @@ class ZombieDriverTest extends JavascriptDriverTest
     }
 
     /**
-     * As of 0.10.1, zombie.js doesn't support drag'n'drop
+     * Zombie.js waits until timeout ends before returning control to script (after ->click() call)
      */
-    public function testDragDrop() {}
+    public function testWait()
+    {
+        $this->markTestSkipped('Skipping, until https://github.com/assaf/zombie/issues/614 is fixed');
+    }
 
-    /**
-     * Zombie.js doesn't handle selects without values
-     */
-    public function testIssue193() {}
+    public function testCookie()
+    {
+        $this->markTestSkipped('Skipping, until https://github.com/assaf/zombie/issues/613 is fixed');
+    }
 
-    // Zombie.js doesn't support iFrames switching
-    public function testIFrame() {}
+    public function testVisibility()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t support visibility checking');
+    }
 
-    // Zombie.js doesn't support window switching
-    public function testWindow() {}
+    public function testDragDrop()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t support drag-n-drop operations since v0.10.1');
+    }
+
+    public function testIssue193()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t handle SELECT without values');
+    }
+
+    public function testIFrame()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t support iFrames switching');
+    }
 
     public function testSetUserAgent()
     {
-        $this->getSession()->setRequestHeader('user-agent', 'foo bar');
-        $this->getSession()->visit($this->pathTo('/headers.php'));
-        $this->assertContains('foo bar', $this->getSession()->getPage()->getText());
+        $session = $this->getSession();
+
+        $session->setRequestHeader('user-agent', 'foo bar');
+        $session->visit($this->pathTo('/headers.php'));
+        $this->assertContains('foo bar', $session->getPage()->getText());
     }
 
     /**


### PR DESCRIPTION
1. removing strict dependency to 0.12.15 version of Zombie (now should work with 2.0.x+)
2. using dev tests from Mink
3. using `json_encode` to escape PHP variables, used in JavaScript
4. fixed cookie setting code
5. fixed element location code (argument order)
6. special processing, when no element was found by xpath
7. removed code duplication in `click` method (for `click` event firing)
8. commented-out `isVisible` method, since there is no 100% safe way to detect this through JavaScript anyway
9. wait timeout of `wait` method was set to incorrect browser property
10. added method for getting last error (for debugging)
11. ignoring `testWait` test, because of how `wait` waits until `setTimeout` runs
12. Making `wait` method return check result (fixes #39).
13. Updating docs to indicate compatibility with 2.0.0 version
14. Adding support for window switching, since 2.0.0 version supports it (improved window tests, that pass in https://github.com/Behat/Mink/pull/400)
15. Removing non-working methods and explicitly skipping non-supported tests
