### PR TITLE
Make `testCookie` test pass again

### DIFF
--- a/src/Behat/Mink/Driver/NodeJS/Server/ZombieServer.php
+++ b/src/Behat/Mink/Driver/NodeJS/Server/ZombieServer.php
@@ -29,11 +29,16 @@ class ZombieServer extends Server
         $js = <<<'JS'
 var net      = require('net')
   , zombie   = require('%modules_path%zombie')
+  , Tough = require('%modules_path%zombie/node_modules/tough-cookie')
   , browser  = null
   , pointers = []
   , buffer   = ""
   , host     = '%host%'
   , port     = %port%;
+
+Tough.Cookie.prototype.cookieString = function cookieString() {
+  return this.key + '=' + (this.value == null ? '' : this.value);
+};
 
 var zombieVersionCompare = function(v2, op) {
   var version_compare = function (v1, v2, operator) {

--- a/tests/Behat/Mink/Driver/ZombieDriverTest.php
+++ b/tests/Behat/Mink/Driver/ZombieDriverTest.php
@@ -25,11 +25,6 @@ class ZombieDriverTest extends JavascriptDriverTest
         $this->markTestSkipped('Skipping, until https://github.com/assaf/zombie/issues/614 is fixed');
     }
 
-    public function testCookie()
-    {
-        $this->markTestSkipped('Skipping, until https://github.com/assaf/zombie/issues/613 is fixed');
-    }
-
     public function testVisibility()
     {
         $this->markTestSkipped('Zombie.js doesn\'t support visibility checking');


### PR DESCRIPTION
In Zombie.Js v2.0.0 decision was made to use https://github.com/goinstant/node-cookie module for cookie processing. It appears though, that `tough-cookie` module quotes cookie values (to follow some new RFC), while building cookie header. However PHP doesn't yet implement that RFC, which results in cookie value surrounded by quotes, when read from PHP (e.g. `"cookie-value"` instead of `cookie-value`).

This is the method in question: https://github.com/goinstant/node-cookie/blob/master/lib/cookie.js#L609-L616

I'm not sure if `tough-cookie` author would change anything to make PHP work, so in this PR I'm patching `tough-cookie` module code directly before allowing Zombie.Js to use it.
