### PR TITLE
Fixing non-working `setBasicAuth` method

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -217,7 +217,10 @@ JS;
      */
     public function setBasicAuth($user, $password)
     {
-        $this->server->evalJS("browser.credentials = { credentials: { schema: 'basic', username: '{$user}', password: '{$password}'}};stream.end();");
+        $userEscaped = json_encode($user);
+        $passwordEscaped = json_encode($password);
+
+        $this->server->evalJS("browser.authenticate().basic({$userEscaped}, {$passwordEscaped});stream.end();");
     }
 
     /**


### PR DESCRIPTION
During major driver code rewrite to work with Zombie.Js 2.0.0+ method `setBasicAuth` wasn't rewritten and wasn't working. However there was no a test to tell about it.

Implementation of functionality discussed in https://github.com/Behat/Mink/issues/401.
