### PR TITLE
Fix `setValue` and `getValue` method when working with `textarea` elements

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -496,7 +496,7 @@ if (tagName == "INPUT") {
     value = node.value;
   }
 } else if (tagName == "TEXTAREA") {
-  value = node.text;
+  value = node.value;
 } else if (tagName == "SELECT") {
   if (node.getAttribute('multiple')) {
     value = [];
@@ -537,18 +537,13 @@ JS;
 
         $js = <<<JS
 var node = {$ref},
-    tagName = node.tagName;
-if (tagName == "TEXTAREA") {
-  node.textContent = {$value};
+    type = node.getAttribute('type');
+if (type == 'checkbox') {
+  {$value} ? browser.check(node) : browser.uncheck(node);
+} else if (type == 'radio') {
+  browser.choose(node);
 } else {
-  var type = node.getAttribute('type');
-  if (type == "checkbox") {
-    {$value} ? browser.check(node) : browser.uncheck(node);
-  } else if (type == "radio") {
-    browser.choose(node);
-  } else {
-    browser.fill(node, {$value});
-  }
+  browser.fill(node, {$value});
 }
 stream.end();
 JS;


### PR DESCRIPTION
1. Removing dedicated code in `setValue` method for textarea (code taken from #27 and formatted properly).
2. Fixed non-working `getValue` method for textarea (code taken from #25 as is)
