### PR TITLE
Cookie was only deleted from current path

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -137,13 +137,8 @@ class ZombieDriver extends CoreDriver
      */
     public function reset()
     {
-        // Cleanup cached references
-        $this->nativeRefs = array();
-
         $js = <<<JS
 browser.deleteCookies();
-browser = null;
-pointers = [];
 stream.end();
 JS;
 
@@ -307,9 +302,13 @@ JS;
         $nameEscaped = json_encode($name);
 
         $js = <<<JS
-var cookieId = {name: {$nameEscaped}, domain: browser.window.location.hostname};
+var path = browser.window.location.pathname;
 
-browser.deleteCookie(cookieId);
+do {
+    browser.deleteCookie({name: {$nameEscaped}, domain: browser.window.location.hostname, path: path});
+    path = path.replace(/.$/, '');
+} while (path);
+
 stream.end();
 JS;
 


### PR DESCRIPTION
When deleting a cookie using `->setCookie('cookieName')` code, then only cookie from current path was deleted. This way if cookie was set on `/index.html` page, then it could not be deleted, while being on `/sub-folder/sub-page.html`.

Here I'm also bringing `->reset()` method of Session up to date with other drivers, so now it ONLY deletes all cookies and nothing more. Before it was also dropping current Zombie browser instance, which resulted in loosing `browser.window` object, which contained information about currently opened page.    

Tests in https://github.com/Behat/Mink/pull/418
