### PR TITLE
Convert tag names to lowercase for comparisons in JS

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -481,9 +481,9 @@ JS;
 
         $js = <<<JS
 var node = {$ref},
-    tagName = node.tagName,
+    tagName = node.tagName.toLowerCase(),
     value = null;
-if (tagName == "INPUT") {
+if (tagName == "input") {
   var type = node.getAttribute('type').toLowerCase();
   if (type == "checkbox") {
     value = node.checked;
@@ -498,9 +498,9 @@ if (tagName == "INPUT") {
   } else {
     value = node.value;
   }
-} else if (tagName == "TEXTAREA") {
+} else if (tagName == "textarea") {
   value = node.value;
-} else if (tagName == "SELECT") {
+} else if (tagName == "select") {
   if (node.getAttribute('multiple')) {
     value = [];
     for (var i = 0; i < node.options.length; i++) {
@@ -613,10 +613,10 @@ JS;
         $value = json_encode($value);
         $js = <<<JS
 var node = {$ref},
-    tagName = node.tagName;
-if (tagName == "SELECT") {
+    tagName = node.tagName.toLowerCase();
+if (tagName == "select") {
   browser.select(node, {$value});
-} else if (tagName == "INPUT") {
+} else if (tagName == "input") {
   var type = node.getAttribute('type');
   if (type == "radio") {
     browser.choose(node);


### PR DESCRIPTION
As described in Behat/MinkSelenium2Driver#105, some browsers use uppercase for tag names, while others use lower case. The handling of this in Mink's drivers is inconsistent.

To make it consistent, all drivers should case-fold tag names and should use lower case for comparison in JS code.
### Tests

I wasn't able to get the tests working. This may be the result of an issue in Zombie.js or JSDOM. If someone wants to help me debug, I'd be happy to run tests, but I'm stuck as it is. This is a pretty low risk change, so might be fine to commit without running the tests.
