### PR TITLE
Don’t perform HTML decoding before returning from `getContent` method

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -353,7 +353,7 @@ JS;
      */
     public function getContent()
     {
-        return $this->server->evalJS('browser.html()', 'json');
+        return $this->server->evalJS('browser.source', 'json');
     }
 
     /**


### PR DESCRIPTION
Corresponding tests are added here: Behat/Mink#458

Fixes #9
