### PR TITLE
Skipped HTML5 form attribute tests as it is not supported by Zombie.js

### DIFF
--- a/tests/Behat/Mink/Driver/ZombieDriverTest.php
+++ b/tests/Behat/Mink/Driver/ZombieDriverTest.php
@@ -42,6 +42,21 @@ class ZombieDriverTest extends JavascriptDriverTest
         $this->markTestSkipped('Zombie.js doesn\'t support iFrames switching');
     }
 
+    public function testHtml5FormInputAttribute()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t HTML5 form attributes. See https://github.com/assaf/zombie/issues/635');
+    }
+
+    public function testHtml5FormButtonAttribute()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t HTML5 form attributes. See https://github.com/assaf/zombie/issues/635');
+    }
+
+    public function testHtml5FormOutside()
+    {
+        $this->markTestSkipped('Zombie.js doesn\'t HTML5 form attributes. See https://github.com/assaf/zombie/issues/635');
+    }
+
     public function testSetUserAgent()
     {
         $session = $this->getSession();


### PR DESCRIPTION
This will allow failures in the driver testsuite for now until https://github.com/assaf/zombie/issues/635 is fixed, as there is nothing we could do here anyway
