### PR TITLE
Wrap JavaScript errors on NodeJS process side into PHP's DriverException

### DIFF
--- a/src/Behat/Mink/Driver/NodeJS/Server.php
+++ b/src/Behat/Mink/Driver/NodeJS/Server.php
@@ -379,6 +379,7 @@ abstract class Server
      * @param   string                                $returnType  The return type
      *
      * @return  string  The eval'ed response
+     * @throws \InvalidArgumentException When unsupported $returnType given.
      */
     abstract protected function doEvalJS(Connection $conn, $str, $returnType = 'js');
 
@@ -394,6 +395,7 @@ abstract class Server
             if (null === $this->process) {
                 throw new \RuntimeException("No connection available. Did you start the server?");
             }
+
             if ($this->process->isRunning()) {
                 $this->stop();
                 throw new \RuntimeException(sprintf(
@@ -402,6 +404,7 @@ abstract class Server
                 ));
             }
         }
+
         if (!$this->process->isRunning()) {
             throw new \RuntimeException(sprintf(
                 "Server process has been terminated: (%s) [%s]",
@@ -422,7 +425,8 @@ abstract class Server
             '%host%'         => $this->host,
             '%port%'         => $this->port,
             '%modules_path%' => $this->nodeModulesPath,
-          ));
+        ));
+
         $serverPath = tempnam(sys_get_temp_dir(), 'mink_nodejs_server');
         file_put_contents($serverPath, $serverScript);
 

--- a/tests/Behat/Mink/Driver/NodeJS/ServerTest.php
+++ b/tests/Behat/Mink/Driver/NodeJS/ServerTest.php
@@ -124,6 +124,10 @@ JS;
         $server->start();
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Server did not respond in time: (1) [Stopped]
+     */
     public function testStartServerThatDoesNotRespondInTime()
     {
         $process = $this->getNotRespondingServerProcessMock();
@@ -133,17 +137,13 @@ JS;
         $serverPath = __DIR__.'/server-fixtures/test_server.js';
         $server = new TestServer('127.0.0.1', 8124, null, $serverPath, 10000);
 
-        try {
-            $server->start($process);
-            $this->fail('No exception thrown');
-        } catch (\RuntimeException $ex) {
-            $this->assertEquals(
-                "Server did not respond in time: (1) [Stopped]",
-                $ex->getMessage()
-            );
-        }
+        $server->start($process);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Server process has been terminated: (1) [TROLOLOLO]
+     */
     public function testStartServerThatWasTerminated()
     {
         $process = $this->getTerminatedServerProcessMock();
@@ -153,15 +153,7 @@ JS;
         $serverPath = __DIR__.'/server-fixtures/test_server.js';
         $server = new TestServer('127.0.0.1', 8124, null, $serverPath, 10000);
 
-        try {
-            $server->start($process);
-            $this->fail('No exception thrown');
-        } catch (\RuntimeException $ex) {
-            $this->assertEquals(
-                "Server process has been terminated: (1) [TROLOLOLO]",
-                $ex->getMessage()
-            );
-        }
+        $server->start($process);
     }
 
     public function testStartServerSuccessfully()
@@ -218,6 +210,7 @@ JS;
         $this->assertTrue($server->isRunning());
 
         $process = $this->getTerminatedServerProcessMock();
+
         try {
             $server->start($process);
         } catch (\RuntimeException $ex) {


### PR DESCRIPTION
Now the failed test output looks much cleaner because NodeJS process don't crash after JS error happened.

Tests still failing though, but it wasn't the point of this PR to fix them :smile: 

Fixes #72
