### PR TITLE
Switched an helper method to private visibility

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -256,7 +256,7 @@ JS;
         $this->server->evalJS($js);
     }
 
-    protected function deleteCookie($name)
+    private function deleteCookie($name)
     {
         $nameEscaped = json_encode($name);
 


### PR DESCRIPTION
this method was not yet released, so it is not a BC break.

Regarding the other protected methods, 3 of them are already part of 1.1.0 so they need to be kept protected for BC.
the last one is `getLastError` which is not used anywhere. What is its goal ?
