### PR TITLE
Retrieving last response headers from correct place

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -229,7 +229,7 @@ JS;
      */
     public function getResponseHeaders()
     {
-        return (array)$this->server->evalJS('browser.lastResponse.headers', 'json');
+        return (array)$this->server->evalJS('browser.window._response.headers', 'json');
     }
 
     /**


### PR DESCRIPTION
Regardless of `_response` usage (which looks like it was meant to be private) I can tell only that Zombie itself is using it the same way to retrieve the HTTP code of last page visit in current browser window (see https://github.com/assaf/zombie/blob/6cb0b8488b2ae3e4a2a44da8ed4963687ba18a5c/src/zombie/browser.coffee#L1140).

Fixes #74
