### PR TITLE
Improved the resetting of the driver by recreating the Zombie instance

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -108,11 +108,13 @@ class ZombieDriver extends CoreDriver
     public function reset()
     {
         $js = <<<JS
-browser.deleteCookies();
+browser.destroy();
+browser = null;
 stream.end();
 JS;
 
         $this->server->evalJS($js);
+        $this->nativeRefs = array();
     }
 
     /**


### PR DESCRIPTION
This should fix https://github.com/Behat/MinkZombieDriver/issues/80 by starting from a clean state
