### PR TITLE
Fixed getting the value of a radio group when several forms use the name

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -421,11 +421,20 @@ if (tagName == "input") {
   if (type == "checkbox") {
     value = node.checked ? node.value : null;
   } else if (type == "radio") {
-    var name = node.getAttribute('name');
-    if (name) {
-      var field = browser.field("input[type='radio'][name='" + name + "']:checked");
-      if (field) {
-        value = field.value;
+    if (node.checked) {
+      value = node.value;
+    } else {
+      var name = node.getAttribute('name');
+      if (name) {
+        var formElements = node.form.elements,
+            element;
+        for (var i = 0; i < formElements.length; i++) {
+          element = formElements[i];
+          if (element.type == 'radio' && element.getAttribute('name') === name && element.checked) {
+            value = element.value;
+            break;
+          }
+        }
       }
     }
   } else {


### PR DESCRIPTION
`getValue` was broken in 2 cases for radio buttons:
- radio inputs without a name when the node passed to the method is checked
- multiple input groups with the same name in different forms on the same page

Ref #98
