### PR TITLE
Fixed the retrieval of the value of options

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -459,7 +459,7 @@ if (tagName == "input") {
     }
   }
 } else {
-  value = node.getAttribute('value');
+  value = node.value;
 }
 stream.end(JSON.stringify(value));
 JS;


### PR DESCRIPTION
The DOM property should be used rather than getting the attribute directly, to support properly elements which have a fallback behavior when their value attribute is missing (option elements are using their text in such case).

This fixes the test failure for options without values. refs #98  
