### PR TITLE
Skip the test about keyup events when setting a text value

### DIFF
--- a/tests/ZombieConfig.php
+++ b/tests/ZombieConfig.php
@@ -46,6 +46,10 @@ class ZombieConfig extends AbstractConfig
             return 'Zombie automatically waits for events to fire, so the wait test is irrelevant';
         }
 
+        if ('Behat\Mink\Tests\Driver\Js\ChangeEventTest' === $testCase && 'testIssue178' === $test) {
+            return 'Zombie does not trigger the keyup event when writing a value in a text input to simulate keyboard';
+        }
+
 
         return parent::skipMessage($testCase, $test);
     }


### PR DESCRIPTION
Zombie does not simulate the keyboard events when filling a field, so running this test does not make sense

This will remove the failure number 6 of #98
