### PR TITLE
Added the possibility to configure the node modules path in tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <var name="driver_config_factory" value="Behat\Mink\Tests\Driver\ZombieConfig::getInstance" />
 
         <!--server name="WEB_FIXTURES_HOST" value="http://test.mink.dev" /-->
+        <!--server name="NODE_MODULES_PATH" value="path/to/ZombieDriver/node_modules/" /-->
     </php>
 
     <filter>

--- a/tests/ZombieConfig.php
+++ b/tests/ZombieConfig.php
@@ -19,6 +19,10 @@ class ZombieConfig extends AbstractConfig
     {
         $server = new ZombieServer('127.0.0.1', 8124, 'node');
 
+        if (isset($_SERVER['NODE_MODULES_PATH'])) {
+            $server->setNodeModulesPath($_SERVER['NODE_MODULES_PATH']);
+        }
+
         return new ZombieDriver($server);
     }
 


### PR DESCRIPTION
This allows to run the testsuite when the node_modules cannot be auto-detected (it looks like the globally installed packages using the Ubuntu setup are not in a path looked by `require` by default, and the current folder is not a parent of the temp folder where the server script gets created, meaning that both the global and local installs are not working without some config on my Ubuntu setup) 
