### PR TITLE
Fixed the implementation of wait

### DIFF
--- a/src/Behat/Mink/Driver/ZombieDriver.php
+++ b/src/Behat/Mink/Driver/ZombieDriver.php
@@ -805,8 +805,7 @@ JS;
     return browser.evaluate($conditionEscaped);
   };
 
-  browser.waitDuration = {$timeout};
-  browser.wait(checkCondition).then(function () {
+  browser.wait({function: checkCondition, duration: $timeout}, function () {
     stream.end(JSON.stringify(checkCondition()));
   });
 }());


### PR DESCRIPTION
The 2.0 release of Zombie changed the behavior of `browser.wait(function)` to consider it as the callback rather than the completion function, thus not returning a closure.
The completion function is not passed in the options, together with the duration instead of changing the global setting. The callback is also passed directly rather than using the promise-based API to avoid [a bug](https://github.com/assaf/zombie/issues/755) in Zombie 2.0.0 to at least 2.0.3 when using wait() without opening a page.
