### PR TITLE
Add a dependency on PHP's sockets extension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
 
     "require": {
+        "ext-sockets":      "*",
         "php":              ">=5.3.1",
         "behat/mink":       "~1.7@dev",
         "symfony/process":  "~2.1"


### PR DESCRIPTION
`Behat\Mink\Driver\NodeJS\Connection` calls `socket_create`, which is part of PHP's sockets extension. Because Composer does not check for this dependency, this code can be executed and fail on systems that don't have the extension.