### PR TITLE
Call the stop() method on the server no matter how PHP shutsdown

### DIFF
--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -32,6 +32,12 @@ class ZombieDriver extends CoreDriver
      */
     public function __construct($serverOrHost, $port = null)
     {
+        // Ensure that the "stop" method gets called no matter
+        // how the PHP execution finishes.
+        if (function_exists("register_shutdown_function")) {
+          register_shutdown_function(array($this, 'stop'));
+        }
+
         if ($serverOrHost instanceof ZombieServer) {
             $this->server = $serverOrHost;
 

--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -34,9 +34,7 @@ class ZombieDriver extends CoreDriver
     {
         // Ensure that the "stop" method gets called no matter
         // how the PHP execution finishes.
-        if (function_exists("register_shutdown_function")) {
-          register_shutdown_function(array($this, 'stop'));
-        }
+        register_shutdown_function(array($this, 'stop'));
 
         if ($serverOrHost instanceof ZombieServer) {
             $this->server = $serverOrHost;


### PR DESCRIPTION
As mentioned in the issue, I am not sure how to write a test for it.

Closes #120 