### PR TITLE
Upgrade the authentication logic for Zombie 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: php
 
 php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
+matrix:
+  include:
+    - php: 5.6
+      env: ZOMBIE_VERSION='@^2.0'
+
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost
 
@@ -13,7 +18,7 @@ before_script:
   - sudo sed -i -e "s,/var/www,$(pwd)/vendor/behat/mink/driver-testsuite/web-fixtures,g" /etc/apache2/sites-available/default
   - sudo /etc/init.d/apache2 restart
 
-  - npm install zombie
+  - npm install zombie$ZOMBIE_VERSION
 
   - export NODE_PATH="$(pwd)/node_modules"
   - export PATH="/usr/local/share/npm/bin:$PATH"


### PR DESCRIPTION
This fixes #128. I chose the easy way for now by forcing to use Zombie 3.

It would not be a lot more difficult to support both 2.x and 3.x at the same time as we are not affected by other BC breaks (at least as far as our testsuite is catching). What would be our choice on this @aik099 ?