### PR TITLE
Append error output to triggerBrowserEvent DriveException message

### DIFF
--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -869,7 +869,7 @@ browser.fire({$ref}, "{$event}", function (err) {
 JS;
         $out = $this->server->evalJS($js);
         if (!empty($out)) {
-            throw new DriverException(sprintf("Error while processing event '%s'", $event));
+            throw new DriverException(sprintf("Error while processing event '%s': %s", $event, $out));
         }
     }
 


### PR DESCRIPTION
There's currently not much visibility on what causes browser event errors, usually I have to run through the feature manually to see what the console error is.

Appending the eval output provides a more useful message.

![screen shot 2015-07-10 at 4 37 28 pm](https://cloud.githubusercontent.com/assets/51677/8622200/0df12cea-2722-11e5-8f49-0846e6869d1d.png)
