### PR TITLE
Switch to the container-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: php
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
 php: [5.3, 5.4, 5.5, 5.6, 7, hhvm]
 
 env:
   global:
     - IOJS_VERSION=''
     - ZOMBIE_VERSION='@^3.0' # npm will install Zombie 4.x by default, even though it is not compatible with node...
+    - WEB_FIXTURES_HOST=http://localhost:8000
 
 matrix:
   include:
@@ -19,19 +26,15 @@ matrix:
     - php: 7
 
 before_script:
-  - export WEB_FIXTURES_HOST=http://localhost
-
   # Install deps
-  - composer install --prefer-source
+  - composer install
 
-  - sudo apt-get update > /dev/null
-  - sudo apt-get install -y --force-yes apache2 libapache2-mod-php5
-  - sudo sed -i -e "s,/var/www,$(pwd)/vendor/behat/mink/driver-testsuite/web-fixtures,g" /etc/apache2/sites-available/default
-  - sudo /etc/init.d/apache2 restart
+   # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
+  - ~/.phpenv/versions/5.6/bin/php -S 127.0.0.1:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
 
   - npm install zombie$ZOMBIE_VERSION
 
-  - export NODE_PATH="$(pwd)/node_modules"
+  - export NODE_MODULES_PATH="$(pwd)/node_modules/"
 
   - if [[ "$IOJS_VERSION" != "" ]]; then wget https://iojs.org/dist/v${IOJS_VERSION}/iojs-v${IOJS_VERSION}-linux-x64.tar.xz && tar xf iojs-v${IOJS_VERSION}-linux-x64.tar.xz && export NODE_BIN="`pwd`/iojs-v${IOJS_VERSION}-linux-x64/bin/node"; fi
 


### PR DESCRIPTION
This uses the PHP builtin webserver to expose web fixtures rather than installing Apache. This relies on the fact that PHP 5.6 is installed on Travis even on jobs running with a different version, and so can be used for fixtures on all jobs (and we don't care about the PHP version used to run fixtures as we were not using the Travis one before anyway).