### PR TITLE
Switch to main window on soft session reset

### DIFF
--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -94,13 +94,13 @@ class ZombieDriver extends CoreDriver
     public function reset()
     {
         $js = <<<JS
-browser.destroy();
-browser = null;
+browser.headers = {};
+browser.deleteCookies();
 stream.end();
 JS;
 
         $this->server->evalJS($js);
-        $this->nativeRefs = array();
+        $this->setBasicAuth(false, '');
     }
 
     /**

--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -101,6 +101,7 @@ JS;
 
         $this->server->evalJS($js);
         $this->setBasicAuth(false, '');
+        $this->switchToWindow(null);
     }
 
     /**

--- a/tests/Custom/ExtraTest.php
+++ b/tests/Custom/ExtraTest.php
@@ -26,4 +26,19 @@ class ExtraTest extends TestCase
         $this->getSession()->visit($this->pathTo('/headers.php'));
         $this->assertContains('[HTTP_FOO] => bar', $this->getSession()->getPage()->getText());
     }
+
+    public function testSessionResetSwitchesToMainWindow()
+    {
+        $this->getSession()->visit($this->pathTo('/window.html'));
+        $session = $this->getSession();
+        $page = $session->getPage();
+        $webAssert = $this->getAssertSession();
+
+        $page->clickLink('Popup #1');
+        $session->switchToWindow('popup_1');
+        $session->reset();
+
+        $el = $webAssert->elementExists('css', '#text');
+        $this->assertSame('Main window div text', $el->getText());
+    }
 }


### PR DESCRIPTION
Also changed implementation of `reset` method to resemle what Selenium2 does (keep all opened windows and clean cookies). Because of Zombie keeps state within itself the headers and authentification were also cleaned.

Thanks to these extra changes the session is usable after `->reset()` is called. Before the exception was thrown.

Closes #142