### PR TITLE
Add strictSSL support

### DIFF
--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -61,6 +61,11 @@ abstract class Server
     protected $connection;
 
     /**
+     * @var boolean
+     */
+    protected $strictSSL;
+
+    /**
      * Constructor
      *
      * @param string $host            The server host
@@ -231,6 +236,28 @@ abstract class Server
     public function getThreshold()
     {
         return $this->threshold;
+    }
+
+    /**
+     * Setter strict SSL
+     *
+     * @param boolean Whether to use strictSSL or not.
+     *
+     */
+    public function setStrictSSL($strict = TRUE)
+    {
+        return $this->strictSSL = $strict;
+    }
+
+    /**
+     * Getter strict SSL
+     *
+     * @return boolean Whether to use strictSSL or not.
+     *
+     */
+    public function getStrictSSL()
+    {
+        return $this->strictSSL;
     }
 
     /**
@@ -423,6 +450,7 @@ abstract class Server
             '%host%'         => $this->host,
             '%port%'         => $this->port,
             '%modules_path%' => $this->nodeModulesPath,
+            '%strict_ssl%'   => $this->strictSSL,
         ));
 
         $serverPath = tempnam(sys_get_temp_dir(), 'mink_nodejs_server');

--- a/src/NodeJS/Server/ZombieServer.php
+++ b/src/NodeJS/Server/ZombieServer.php
@@ -174,6 +174,7 @@ net.createServer(function (stream) {
   stream.on('end', function () {
     if (browser == null) {
       browser = new zombie();
+      browser.strictSSL = %strict_ssl%;
 
       // Clean up old pointers
       pointers = [];


### PR DESCRIPTION
Supporting the `strictSSL` option for Zombie allows developers to turn off strict certificate tests that stop self-signed/development certificates in some cases.

I still need to figure out how this would be passed in from outside mink itself (from behat for example).