### PR TITLE
Extract the node server script to a dedicated bin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php: [5.3, 5.4, 5.5, 5.6, 7.0, hhvm]
 env:
   global:
     - NODE_VERSION=''
-    - ZOMBIE_VERSION='@^3.0' # npm will install Zombie 4.x by default, even though it is not compatible with node...
+    - ZOMBIE_VERSION='@^3.0' # npm will install Zombie 4.x by default, even though it is not compatible with the version of node available on Travis.
     - WEB_FIXTURES_HOST=http://localhost:8000
 
 matrix:
@@ -31,8 +31,6 @@ before_script:
   - ~/.phpenv/versions/5.6/bin/php -S 127.0.0.1:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
 
   - npm install zombie$ZOMBIE_VERSION
-
-  - export NODE_MODULES_PATH="$(pwd)/node_modules/"
 
   - if [[ "$NODE_VERSION" != "" ]]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && tar xf node-v${NODE_VERSION}-linux-x64.tar.xz && export NODE_BIN="`pwd`/node-v${NODE_VERSION}-linux-x64/bin/node"; fi
 

--- a/bin/mink-zombie-server.js
+++ b/bin/mink-zombie-server.js
@@ -1,0 +1,132 @@
+#!/usr/bin/node
+var net = require('net');
+var zombie = require('zombie');
+var Tough = require('zombie/node_modules/tough-cookie');
+var browser = null;
+var pointers = [];
+var buffer = '';
+var host = process.env.HOST || '127.0.0.1';
+var port = process.env.PORT || 8124;
+
+Tough.Cookie.prototype.cookieString = function cookieString() {
+    return this.key + '=' + (this.value == null ? '' : this.value);
+};
+
+var zombieVersionCompare = function (v2, op) {
+    var version_compare = function (v1, v2, operator) {
+        var i = 0,
+            x = 0,
+            compare = 0,
+            vm = {
+                'dev': -6,
+                'alpha': -5,
+                'a': -5,
+                'beta': -4,
+                'b': -4,
+                'RC': -3,
+                'rc': -3,
+                '#': -2,
+                'p': 1,
+                'pl': 1
+            },
+            prepVersion = function (v) {
+                v = ('' + v).replace(/[_\-+]/g, '.');
+                v = v.replace(/([^.\d]+)/g, '.$1.').replace(/\.{2,}/g, '.');
+
+                return (!v.length ? [-8] : v.split('.'));
+            },
+            numVersion = function (v) {
+                return !v ? 0 : (isNaN(v) ? vm[v] || -7 : parseInt(v, 10));
+            };
+
+        v1 = prepVersion(v1);
+        v2 = prepVersion(v2);
+        x = Math.max(v1.length, v2.length);
+
+        for (i = 0; i < x; i++) {
+            if (v1[i] == v2[i]) {
+                continue;
+            }
+
+            v1[i] = numVersion(v1[i]);
+            v2[i] = numVersion(v2[i]);
+
+            if (v1[i] < v2[i]) {
+                compare = -1;
+                break;
+            } else if (v1[i] > v2[i]) {
+                compare = 1;
+                break;
+            }
+        }
+
+        if (!operator) {
+            return compare;
+        }
+
+        switch (operator) {
+            case '>':
+            case 'gt':
+                return (compare > 0);
+
+            case '>=':
+            case 'ge':
+                return (compare >= 0);
+
+            case '<=':
+            case 'le':
+                return (compare <= 0);
+
+            case '==':
+            case '=':
+            case 'eq':
+                return (compare === 0);
+
+            case '<>':
+            case '!=':
+            case 'ne':
+                return (compare !== 0);
+
+            case '':
+            case '<':
+            case 'lt':
+                return (compare < 0);
+        }
+
+        return null;
+    };
+
+    return version_compare(require('zombie/package').version, v2, op);
+};
+
+if (false == zombieVersionCompare('2.0.0', '>=')) {
+    throw new Error("Your zombie.js version is not compatible with this driver. Please use a version >= 2.0.0");
+}
+
+net.createServer(function (stream) {
+    stream.setEncoding('utf8');
+    stream.allowHalfOpen = true;
+
+    stream.on('data', function (data) {
+        buffer += data;
+    });
+
+    stream.on('end', function () {
+        if (browser == null) {
+            browser = new zombie();
+
+            // Clean up old pointers
+            pointers = [];
+        }
+
+        try {
+            eval(buffer);
+            buffer = '';
+        } catch (e) {
+            buffer = '';
+            stream.end('CAUGHT_ERROR:' + JSON.stringify(e.message));
+        }
+    });
+}).listen(port, host, function () {
+    console.log('server started on ' + host + ':' + port);
+});

--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -276,6 +276,13 @@ abstract class Server
                 $this->nodeBin,
                 $this->serverPath,
             ));
+            $processBuilder->setEnv('HOST', $this->host)
+                ->setEnv('PORT', $this->port);
+
+            if (!empty($this->nodeModulesPath)) {
+                $processBuilder->setEnv('NODE_PATH', $this->nodeModulesPath);
+            }
+
             $process = $processBuilder->getProcess();
         }
         $this->process = $process;
@@ -419,11 +426,16 @@ abstract class Server
      */
     protected function createTemporaryServer()
     {
-        $serverScript = strtr($this->getServerScript(), array(
+        $rawServerScript = $this->getServerScript();
+        $serverScript = strtr($rawServerScript, array(
             '%host%'         => $this->host,
             '%port%'         => $this->port,
             '%modules_path%' => $this->nodeModulesPath,
         ));
+
+        if ($serverScript !== $rawServerScript) {
+            @trigger_error('Using the `%host%`, `%port%` and `%modules_path%` placeholders in the server script is deprecated since ZombieDriver 1.4 and will be removed in 2.0. Rely on the HOST, PORT and NODE_PATH environment variables instead.', E_USER_DEPRECATED);
+        }
 
         $serverPath = tempnam(sys_get_temp_dir(), 'mink_nodejs_server');
         file_put_contents($serverPath, $serverScript);

--- a/src/NodeJS/Server/ZombieServer.php
+++ b/src/NodeJS/Server/ZombieServer.php
@@ -51,147 +51,25 @@ class ZombieServer extends Server
         return $result;
     }
 
+    protected function createTemporaryServer()
+    {
+        // If the driver is running in a phar, we need to create a temporary script
+        // outside the phar to be usable by node. Otherwise, we use the script directly
+        // as this gives a better user experience when zombie is installed locally
+        // in the project using the driver (as node will be able to find zombie without
+        // having to configure the node modules path).
+        if ('phar:' === substr(__DIR__, 0, 5)) {
+            return parent::createTemporaryServer();
+        }
+
+        return realpath(__DIR__.'/../../../bin/mink-zombie-server.js');
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function getServerScript()
     {
-        $errorPrefix = self::ERROR_PREFIX;
-
-        $js = <<<JS
-var net      = require('net')
-  , zombie   = require('%modules_path%zombie')
-  , Tough = require('%modules_path%zombie/node_modules/tough-cookie')
-  , browser  = null
-  , pointers = []
-  , buffer   = ''
-  , host     = '%host%'
-  , port     = %port%;
-
-Tough.Cookie.prototype.cookieString = function cookieString() {
-  return this.key + '=' + (this.value == null ? '' : this.value);
-};
-
-var zombieVersionCompare = function (v2, op) {
-  var version_compare = function (v1, v2, operator) {
-    var i = 0,
-        x = 0,
-        compare = 0,
-        vm = {
-          'dev': -6,
-          'alpha': -5,
-          'a': -5,
-          'beta': -4,
-          'b': -4,
-          'RC': -3,
-          'rc': -3,
-          '#': -2,
-          'p': 1,
-          'pl': 1
-        },
-        prepVersion = function (v) {
-          v = ('' + v).replace(/[_\-+]/g, '.');
-          v = v.replace(/([^.\d]+)/g, '.$1.').replace(/\.{2,}/g, '.');
-
-          return (!v.length ? [-8] : v.split('.'));
-        },
-        numVersion = function (v) {
-          return !v ? 0 : (isNaN(v) ? vm[v] || -7 : parseInt(v, 10));
-        };
-
-      v1 = prepVersion(v1);
-      v2 = prepVersion(v2);
-      x = Math.max(v1.length, v2.length);
-
-      for (i = 0; i < x; i++) {
-        if (v1[i] == v2[i]) {
-          continue;
-        }
-
-        v1[i] = numVersion(v1[i]);
-        v2[i] = numVersion(v2[i]);
-
-        if (v1[i] < v2[i]) {
-          compare = -1;
-          break;
-        } else if (v1[i] > v2[i]) {
-          compare = 1;
-          break;
-        }
-      }
-
-      if (!operator) {
-        return compare;
-      }
-
-      switch (operator) {
-        case '>':
-        case 'gt':
-          return (compare > 0);
-
-        case '>=':
-        case 'ge':
-          return (compare >= 0);
-
-        case '<=':
-        case 'le':
-          return (compare <= 0);
-
-        case '==':
-        case '=':
-        case 'eq':
-          return (compare === 0);
-
-        case '<>':
-        case '!=':
-        case 'ne':
-          return (compare !== 0);
-
-        case '':
-        case '<':
-        case 'lt':
-          return (compare < 0);
-      }
-
-      return null;
-  };
-
-  return version_compare(require('%modules_path%zombie/package').version, v2, op);
-};
-
-if (false == zombieVersionCompare('2.0.0', '>=')) {
-  throw new Error("Your zombie.js version is not compatible with this driver. Please use a version >= 2.0.0");
-}
-
-net.createServer(function (stream) {
-  stream.setEncoding('utf8');
-  stream.allowHalfOpen = true;
-
-  stream.on('data', function (data) {
-    buffer += data;
-  });
-
-  stream.on('end', function () {
-    if (browser == null) {
-      browser = new zombie();
-
-      // Clean up old pointers
-      pointers = [];
-    }
-
-    try {
-      eval(buffer);
-      buffer = '';
-    } catch (e) {
-      buffer = '';
-      stream.end('{$errorPrefix}' + JSON.stringify(e.message));
-    }
-  });
-}).listen(port, host, function () {
-  console.log('server started on ' + host + ':' + port);
-});
-JS;
-
-        return $js;
+        return file_get_contents(__DIR__.'/../../../bin/mink-zombie-server.js');
     }
 }


### PR DESCRIPTION
Instead of configuring the host, port and node paths by performing string replacements in the JS source code, the script now receives the host and port through environment variables, and the node paths are handled through the builtin NODE_PATH environment variable.

This change opens the way to being able to run the server manually separately (as it is now a working node script which can be launched separately), but also to a bigger refactoring of the driver to move more logic to the node script instead of sending it code to eval (see #104).
Such refactoring will come in separate PRs though (and maybe not soon).

This PR should be fully backward compatible (except if people were getting the output of the protected method ``getServerScript`` to run their own process instead of letting our codebase build the process, which would then miss the env variables), but I don't see any reason to do it and it would be quite insane as this involves protected APIs)

Closes #161