### PR TITLE
Don't create a temporary server when setting the node modules path

### DIFF
--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -180,7 +180,6 @@ abstract class Server
             ));
         }
         $this->nodeModulesPath = $nodeModulesPath;
-        $this->serverPath = $this->createTemporaryServer();
     }
 
     /**


### PR DESCRIPTION
Forcing to create a temporary server is breaking the support of custom server scripts (for people wanting to do it for whatever reason).
Rebuilding the server is also useless now that the script does not uses replacements but environment variables.

Closes #160.

This would break the usage of the setter for people using their own Server implementation not updated to stop using replacements, but this should not be common (and I wouldn't consider it as a supported usage). People using ZombieDriver must be using the ZombieServer class anyway, so no BC break for them