### PR TITLE
Support and test installation with npm v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ before_script:
    # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
   - ~/.phpenv/versions/5.6/bin/php -S 127.0.0.1:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
 
-  - npm install zombie$ZOMBIE_VERSION
+  - if [[ "$NODE_VERSION" != "" ]]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && tar xf node-v${NODE_VERSION}-linux-x64.tar.xz && export PATH="`pwd`/node-v${NODE_VERSION}-linux-x64/bin:$PATH"; fi
 
-  - if [[ "$NODE_VERSION" != "" ]]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && tar xf node-v${NODE_VERSION}-linux-x64.tar.xz && export NODE_BIN="`pwd`/node-v${NODE_VERSION}-linux-x64/bin/node"; fi
+  - node --version && npm --version
+
+  - npm install zombie$ZOMBIE_VERSION
 
 script: phpunit -v --coverage-clover=coverage.clover
 

--- a/bin/mink-zombie-server.js
+++ b/bin/mink-zombie-server.js
@@ -1,7 +1,20 @@
 #!/usr/bin/env node
 var net = require('net');
 var zombie = require('zombie');
-var Tough = require('zombie/node_modules/tough-cookie');
+var Tough;
+try {
+  // Try require for the npm v3+ location.
+  Tough = require('tough-cookie');
+}
+catch (err) {
+  try {
+    // Try require for the npm v1 and v2 location.
+    Tough = require('zombie/node_modules/tough-cookie');
+  }
+  catch (err) {
+    throw new Error('Cannot find the tough-cookie module');
+  }
+}
 var browser = null;
 var pointers = [];
 var buffer = '';

--- a/bin/mink-zombie-server.js
+++ b/bin/mink-zombie-server.js
@@ -1,25 +1,29 @@
 #!/usr/bin/env node
 var net = require('net');
 var zombie = require('zombie');
-var Tough;
-try {
-  // Try require for the npm v3+ location.
-  Tough = require('tough-cookie');
-}
-catch (err) {
-  try {
-    // Try require for the npm v1 and v2 location.
-    Tough = require('zombie/node_modules/tough-cookie');
-  }
-  catch (err) {
-    throw new Error('Cannot find the tough-cookie module');
-  }
-}
 var browser = null;
 var pointers = [];
 var buffer = '';
 var host = process.env.HOST || '127.0.0.1';
 var port = process.env.PORT || 8124;
+
+var safe_npm_require = function (module_name, parent) {
+  try {
+    // Try require for the npm v3+ location.
+    return require(module_name);
+  }
+  catch (err) {
+    try {
+      // Try require for the npm v1 and v2 location.
+      return require(parent + '/node_modules/' + module_name);
+    }
+    catch (err) {
+      throw new Error('Cannot find the ' + module_name + ' module');
+    }
+  }
+};
+
+var Tough = safe_npm_require('tough-cookie', 'zombie');
 
 Tough.Cookie.prototype.cookieString = function cookieString() {
     return this.key + '=' + (this.value == null ? '' : this.value);


### PR DESCRIPTION
npm v3, the suggested version of npm for Node.js v5, introduced a "flat" module dependency structure. While npm v1 and v2 install the tough-cookie dependency of the zombie module under the zombie module itself (node_modules/zombie/node_modules/tough-cookie), npm v3 likely will not nest the tough-cookie module under zombie but install it at the same level (node_modules/zombie and node_modules/tough-cookie).

If zombie is installed with npm v3, then the mink-zombie-server.js script cannot find the tough-cookie module and the script fails with the error:
```
Error: Cannot find module 'zombie/node_modules/tough-cookie'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/travis/build/arithmetric/MinkZombieDriver/bin/mink-zombie-server.js:4:13)
    at Module._compile (module.js:397:26)
    at Object.Module._extensions..js (module.js:404:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:429:10)
    at startup (node.js:139:18)
    at node.js:999:3
]
```

This error occurs due to the hard-coded path at: https://github.com/minkphp/MinkZombieDriver/blob/master/bin/mink-zombie-server.js#L4

This PR provides compatibility for installations with npm v1/v2 or v3 by trying to load tough-cookie from both paths, the npm v3 flat form first, then the legacy nested form.

Also, this error was not caught by the Travis tests because they were not configured to use the version of npm included with the version of Node.js used. This PR updates the Travis script to use the npm installed with Node.

This test run shows the error when using npm v3 without the code fix: https://travis-ci.org/arithmetric/MinkZombieDriver/jobs/121820946
