### PR TITLE
Remove tough-cookie monkey patch and add testing for npm v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,11 @@ before_script:
    # Start a webserver for web fixtures. Force using PHP 5.6 to be able to run it on PHP 5.3 and HHVM jobs too
   - ~/.phpenv/versions/5.6/bin/php -S 127.0.0.1:8000 -t vendor/behat/mink/driver-testsuite/web-fixtures > /dev/null 2>&1 &
 
-  - npm install zombie$ZOMBIE_VERSION
+  - if [[ "$NODE_VERSION" != "" ]]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && tar xf node-v${NODE_VERSION}-linux-x64.tar.xz && export PATH="`pwd`/node-v${NODE_VERSION}-linux-x64/bin:$PATH"; fi
 
-  - if [[ "$NODE_VERSION" != "" ]]; then wget https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz && tar xf node-v${NODE_VERSION}-linux-x64.tar.xz && export NODE_BIN="`pwd`/node-v${NODE_VERSION}-linux-x64/bin/node"; fi
+  - node --version && npm --version
+
+  - npm install zombie$ZOMBIE_VERSION
 
 script: phpunit -v --coverage-clover=coverage.clover
 

--- a/bin/mink-zombie-server.js
+++ b/bin/mink-zombie-server.js
@@ -1,16 +1,11 @@
 #!/usr/bin/env node
 var net = require('net');
 var zombie = require('zombie');
-var Tough = require('zombie/node_modules/tough-cookie');
 var browser = null;
 var pointers = [];
 var buffer = '';
 var host = process.env.HOST || '127.0.0.1';
 var port = process.env.PORT || 8124;
-
-Tough.Cookie.prototype.cookieString = function cookieString() {
-    return this.key + '=' + (this.value == null ? '' : this.value);
-};
 
 var zombieVersionCompare = function (v2, op) {
     var version_compare = function (v1, v2, operator) {


### PR DESCRIPTION
This is an alternative PR to #168 based on discussion there.

Instead of fixing the loading of tough-cookie for npm v3, this removes the monkey patch for tough-cookie. The equivalent fix is part of a version of tough-cookie (v0.12.0) that is required by Zombie v2.0.0 and later. Zombie v2.0.0 or later is required by MinkZombieDriver.

This PR also fixes Travis CI testing for npm v3 (so that npm v3 is tested with Node.js 5).
