### PR TITLE
Add support for zombie options

### DIFF
--- a/bin/mink-zombie-server.js
+++ b/bin/mink-zombie-server.js
@@ -6,6 +6,7 @@ var pointers = [];
 var buffer = '';
 var host = process.env.HOST || '127.0.0.1';
 var port = process.env.PORT || 8124;
+var options = process.env.OPTIONS ? JSON.parse(process.env.OPTIONS) : {};
 
 var zombieVersionCompare = function (v2, op) {
     var version_compare = function (v1, v2, operator) {
@@ -108,7 +109,7 @@ net.createServer(function (stream) {
 
     stream.on('end', function () {
         if (browser == null) {
-            browser = new zombie();
+            browser = new zombie(options);
 
             // Clean up old pointers
             pointers = [];

--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -286,15 +286,10 @@ abstract class Server
      *
      * @param array $options Options array
      *
-     * @throws \InvalidArgumentException Invalid path is invalid.
      * @throws \LogicException When server is already running.
      */
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
-        if (!is_array($options)) {
-            throw new \InvalidArgumentException("Options must be specified as an array.");
-        }
-
         if ($this->isRunning()) {
             throw new \LogicException('Unable to change options of a running server.');
         }

--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -286,10 +286,15 @@ abstract class Server
      *
      * @param array $options Options array
      *
+     * @throws \InvalidArgumentException Invalid path is invalid.
      * @throws \LogicException When server is already running.
      */
     public function setOptions($options)
     {
+        if (!is_array($options)) {
+            throw new \InvalidArgumentException("Options must be specified as an array.");
+        }
+
         if ($this->isRunning()) {
             throw new \LogicException('Unable to change options of a running server.');
         }

--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -46,6 +46,11 @@ abstract class Server
     protected $threshold;
 
     /**
+     * @var array
+     */
+    protected $options;
+
+    /**
      * @var string The full path to the NodeJS modules directory.
      */
     protected $nodeModulesPath;
@@ -69,6 +74,7 @@ abstract class Server
      * @param string $serverPath      Path to server script
      * @param int    $threshold       Threshold value in micro seconds
      * @param string $nodeModulesPath Path to node_modules directory
+     * @param array  $options         Options array for zombiejs
      */
     public function __construct(
         $host = '127.0.0.1',
@@ -76,7 +82,8 @@ abstract class Server
         $nodeBin = null,
         $serverPath = null,
         $threshold = 2000000,
-        $nodeModulesPath = ''
+        $nodeModulesPath = '',
+        $options = array()
     ) {
         if (null === $nodeBin) {
             $nodeBin = 'node';
@@ -97,6 +104,7 @@ abstract class Server
 
         $this->setServerPath($serverPath);
         $this->setThreshold($threshold);
+        $this->setOptions($options);
     }
 
     /**
@@ -274,6 +282,32 @@ abstract class Server
     }
 
     /**
+     * Setter options value
+     *
+     * @param array $options Options array
+     *
+     * @throws \LogicException When server is already running.
+     */
+    public function setOptions($options)
+    {
+        if ($this->isRunning()) {
+            throw new \LogicException('Unable to change options of a running server.');
+        }
+
+        $this->options = $options;
+    }
+
+    /**
+     * Getter options value
+     *
+     * @return array Options array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
      * Getter process object
      *
      * @return Process The process object
@@ -321,6 +355,10 @@ abstract class Server
 
             if (!empty($this->nodeModulesPath)) {
                 $processBuilder->setEnv('NODE_PATH', $this->nodeModulesPath);
+            }
+
+            if (!empty($this->options)) {
+                $processBuilder->setEnv('OPTIONS', json_encode($this->options));
             }
 
             $process = $processBuilder->getProcess();

--- a/src/NodeJS/Server.php
+++ b/src/NodeJS/Server.php
@@ -48,7 +48,7 @@ abstract class Server
     /**
      * @var array
      */
-    protected $options;
+    private $options;
 
     /**
      * @var string The full path to the NodeJS modules directory.

--- a/tests/Custom/NodeJS/ServerTest.php
+++ b/tests/Custom/NodeJS/ServerTest.php
@@ -17,9 +17,10 @@ class TestServer extends BaseServer
     protected function getServerScript()
     {
         return <<<JS
-var zombie = require('zombie')
-  , host   = process.env.HOST
-  , port   = process.env.PORT;
+var zombie  = require('zombie')
+  , host    = process.env.HOST
+  , port    = process.env.PORT
+  , options = process.env.OPTIONS ? JSON.parse(process.env.OPTIONS) : {};
 JS;
     }
 
@@ -58,11 +59,13 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/path/to/server', $server->getServerPath());
         $this->assertEquals(2000000, $server->getThreshold());
         $this->assertEquals('', $server->getNodeModulesPath());
+        $this->assertEquals(array(), $server->getOptions());
 
         $expected = <<<JS
-var zombie = require('zombie')
-  , host   = process.env.HOST
-  , port   = process.env.PORT;
+var zombie  = require('zombie')
+  , host    = process.env.HOST
+  , port    = process.env.PORT
+  , options = process.env.OPTIONS ? JSON.parse(process.env.OPTIONS) : {};
 JS;
         $this->assertEquals($expected, $server->serverScript);
     }
@@ -90,7 +93,8 @@ JS;
             null,
             null,
             5000000,
-            '../../'
+            '../../',
+            array('waitDuration' => '15s')
         );
 
         $this->assertEquals('123.123.123.123', $server->getHost());
@@ -99,11 +103,13 @@ JS;
         $this->assertEquals('/path/to/server', $server->getServerPath());
         $this->assertEquals(5000000, $server->getThreshold());
         $this->assertEquals('../../', $server->getNodeModulesPath());
+        $this->assertEquals(array('waitDuration' => '15s'), $server->getOptions());
 
         $expected = <<<JS
-var zombie = require('zombie')
-  , host   = process.env.HOST
-  , port   = process.env.PORT;
+var zombie  = require('zombie')
+  , host    = process.env.HOST
+  , port    = process.env.PORT
+  , options = process.env.OPTIONS ? JSON.parse(process.env.OPTIONS) : {};
 JS;
         $this->assertEquals($expected, $server->serverScript);
     }
@@ -156,6 +162,16 @@ JS;
     {
         $server = $this->getRunningServer();
         $server->setThreshold('test');
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Unable to change options of a running server.
+     */
+    public function testSetOptionsOnRunningServer()
+    {
+        $server = $this->getRunningServer();
+        $server->setOptions(array('waitDuration' => '15s'));
     }
 
     /**

--- a/tests/Custom/NodeJS/ServerTest.php
+++ b/tests/Custom/NodeJS/ServerTest.php
@@ -175,6 +175,16 @@ JS;
     }
 
     /**
+     * @expectedException  \InvalidArgumentException
+     * @expectedExceptionMessage Options must be specified as an array.
+     */
+    public function testSetOptionsWithInvalidArgument()
+    {
+        $server = new TestServer();
+        $server->setOptions('/invalid argument/');
+    }
+
+    /**
      * @group legacy
      */
     public function testCreateCustomServerWithPlaceholders()
@@ -231,16 +241,6 @@ JS;
     {
         $server = $this->getRunningServer();
         $server->setNodeModulesPath('../../');
-    }
-
-    /**
-     * @expectedException  \InvalidArgumentException
-     * @expectedExceptionMessage Options must be specified as an array.
-     */
-    public function testSetOptionsWithInvalidArgument()
-    {
-        $server = new TestServer();
-        $server->setOptions('/invalid argument/');
     }
 
     /**

--- a/tests/Custom/NodeJS/ServerTest.php
+++ b/tests/Custom/NodeJS/ServerTest.php
@@ -175,16 +175,6 @@ JS;
     }
 
     /**
-     * @expectedException  \InvalidArgumentException
-     * @expectedExceptionMessage Options must be specified as an array.
-     */
-    public function testSetOptionsWithInvalidArgument()
-    {
-        $server = new TestServer();
-        $server->setOptions('/invalid argument/');
-    }
-
-    /**
      * @group legacy
      */
     public function testCreateCustomServerWithPlaceholders()

--- a/tests/Custom/NodeJS/ServerTest.php
+++ b/tests/Custom/NodeJS/ServerTest.php
@@ -235,6 +235,16 @@ JS;
 
     /**
      * @expectedException  \InvalidArgumentException
+     * @expectedExceptionMessage Options must be specified as an array.
+     */
+    public function testSetOptionsWithInvalidArgument()
+    {
+        $server = new TestServer();
+        $server->setOptions('/invalid argument/');
+    }
+
+    /**
+     * @expectedException  \InvalidArgumentException
      */
     public function testCreateServerWithInvalidNodeModulesPath()
     {


### PR DESCRIPTION
This is a follow up of https://github.com/minkphp/MinkZombieDriver/pull/154.

This PR allows to specify zombie options as an array argument to the server constructor.
I have applied more or less the same logic as for the threshold argument.
Tests have been updated/added too.
I didn't update the README, but instead would issue a PR against the docs repo once this PR here has been approved.
The associated PR for Behat/MinkExtension is https://github.com/Behat/MinkExtension/pull/284