### PR TITLE
Detect javascript errors when visiting a new web page

### DIFF
--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -125,7 +125,10 @@ browser.visit("{$url}", function (err) {
   }
 });
 JS;
-        $this->server->evalJS($js);
+        $out = $this->server->evalJS($js);
+        if (!empty($out)) {
+            throw new DriverException(sprintf('Error when loading page %s: %s', $url, $out));
+        }
     }
 
     /**

--- a/src/ZombieDriver.php
+++ b/src/ZombieDriver.php
@@ -127,7 +127,7 @@ browser.visit("{$url}", function (err) {
 JS;
         $out = $this->server->evalJS($js);
         if (!empty($out)) {
-            throw new DriverException(sprintf('Error when loading page %s: %s', $url, $out));
+            throw new DriverException(sprintf('Error when loading page %s: %s', $url, json_decode($out)));
         }
     }
 


### PR DESCRIPTION
This makes it possible to see what is going on if you visit a web page and it has javascript errors, or the page fails to load for other reasons (f.ex. the server might be down).

Without this fix, after you visit you just get http code 0 instead of 200, and you will not know what is going on.