### PR TITLE
Fixed all tests for PHP 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     },
 
     "require-dev": {
-        "mink/driver-testsuite": "dev-master"
+        "mink/driver-testsuite": "dev-master",
+        "phpunit/phpunit": "^6.0"
     },
 
     "autoload": {

--- a/tests/Custom/InstantiationTest.php
+++ b/tests/Custom/InstantiationTest.php
@@ -3,8 +3,9 @@
 namespace Behat\Mink\Tests\Driver\Custom;
 
 use Behat\Mink\Driver\ZombieDriver;
+use PHPUnit\Framework\TestCase;
 
-class InstantiationTest extends \PHPUnit_Framework_TestCase
+class InstantiationTest extends TestCase
 {
     public function testInstantiateWithServer()
     {

--- a/tests/Custom/NodeJS/ServerTest.php
+++ b/tests/Custom/NodeJS/ServerTest.php
@@ -4,6 +4,7 @@ namespace Behat\Mink\Tests\Driver\Custom\NodeJS;
 
 use Behat\Mink\Driver\NodeJS\Connection;
 use Behat\Mink\Driver\NodeJS\Server as BaseServer;
+use PHPUnit\Framework\TestCase;
 
 class TestServer extends BaseServer
 {
@@ -47,7 +48,7 @@ JS;
     }
 }
 
-class ServerTest extends \PHPUnit_Framework_TestCase
+class ServerTest extends TestCase
 {
     public function testCreateServerWithDefaults()
     {


### PR DESCRIPTION
Tests should be run with phpunit and not simple-phpunit (because PHP 7-1 uses PHPUnit 5.7).