### PR TITLE
Upgrade "actions/upload-artifact" GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,6 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: logs_php-${{ matrix.php }}
+          name: logs_php-${{ matrix.php }}_zombie${{ matrix.zombie }}_node-${{ matrix.node }}
           path: |
             logs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -52,7 +52,7 @@ jobs:
           ini-values: date.timezone=Europe/Paris, error_reporting=-1, display_errors=On
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "${{ matrix.node }}"
 
@@ -78,8 +78,9 @@ jobs:
           vendor/bin/phpunit -v --coverage-clover=coverage.clover
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.clover
 
       - name: Archive logs artifacts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Archive logs artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs_php-${{ matrix.php }}
           path: |


### PR DESCRIPTION
Upgrading "actions/upload-artifact" GitHub Action, because the v2 is used, which causes the build to fail https://github.com/minkphp/MinkZombieDriver/actions/runs/11610353612 with this message:

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

P.S.
While I'm at it I've decided to upgrade other used GitHub Actions as well.